### PR TITLE
Add shebang line

### DIFF
--- a/ytd.py
+++ b/ytd.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re, urllib, os, sys
 import urllib.request
 import urllib.parse


### PR DESCRIPTION
Specifies python3 as the interpreter to be invoked for executing the script.
Fixes #14 .