### PR TITLE
Standardise installation process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# 
+# Makefile for ytd.py
+#
+# author: alan jean
+#         github.com/occupytheweb 
+#
+# usage: 
+#         make              - display a help text describing the goals defined in this makefile
+#         make install      - installs the dependencies required to run ytd.py
+#         make install-dev  - installs the dependencies required to develop ytd.py
+#         make test         - executes the test suite
+#
+
+# Edit these variables according to the package manager you use.
+
+PKG_MANAGER=apt      # Your distro's package mgr. e.g.: Ubuntu/Debian -> apt,
+	                 #                                  opensuse      -> zypper,
+	                 #                                  fedora        -> yum, ...
+
+INSTALL_CMD=install  # The package installation command for your package manager.
+
+PKG_MANAGER_INSTALL_COMMAND=$(PKG_MANAGER) $(INSTALL_CMD)
+
+
+# required to install python packages
+installation-dependencies: ## install pip
+	sudo $(PKG_MANAGER_INSTALL_COMMAND) python3-pip
+
+# required to run ytd.py
+runtime-dependencies: ## install youtube-dl
+	sudo $(PKG_MANAGER_INSTALL_COMMAND) youtube-dl
+
+
+##
+install: installation-dependencies runtime-dependencies ## install dependencies required to run ytd.py
+	pip install -r requirements/prod.txt
+
+install-dev: installation-dependencies runtime-dependencies ## install development dependencies
+	pip install -r requirements/dev.txt
+
+test: ## run test suite
+	pytest
+##
+
+
+# here be dragons
+help: ## show this help text
+	@echo
+	@echo '  Usage:'
+	@echo '    make <target>'
+	@echo
+	@echo '  Targets:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort |                     \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+.PHONY: help
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -8,17 +8,28 @@
 
 This project has been made for educational purposes using python language and does not support or encourage pirating activities.
 
-## Usage
+## Installation
 
 ### Linux and MacOS:
 
-1. Get the youtube-dl package
+1. Clone this repository
+   ```
+   $ git clone https://github.com/ionicc/Youtube-mp3-downloader-light
+   $ cd Youtube-mp3-downloader-light
+   ```
+
+2. Install
 
    ```
-   $ sudo apt-get install youtube-dl
+   $ make install
    ```
 
-2. Clone and extract the repository
+   or,
+   >To install for development:
+   ```
+   $ make install-dev
+   ```
+
 
 3. Run the ytd.py file
 

--- a/README.md
+++ b/README.md
@@ -8,55 +8,50 @@
 
 This project has been made for educational purposes using python language and does not support or encourage pirating activities.
 
+---
+
 ## Installation
 
-### Linux and MacOS:
-
-1. Clone this repository
+**1. Clone this repository**
    ```
    $ git clone https://github.com/ionicc/Youtube-mp3-downloader-light
    $ cd Youtube-mp3-downloader-light
    ```
 
-2. Install
+**2. Setup**
 
-   ```
+### Linux and MacOS:
+   ```bash
    $ make install
    ```
 
    or,
    >To install for development:
-   ```
+   ```bash
    $ make install-dev
    ```
 
-
-3. Run the ytd.py file
-
-   ```
-   ./ytd.py
-   ```
-
 ### Windows:
+   >If you use [make](http://gnuwin32.sourceforge.net/packages/make.htm), follow the steps above.
+   >Else, you need to download [ffmpeg](https://ffmpeg.zeranoe.com/builds/) for your system, then:
 
-1. Clone this Repository.
+   - Unzip the archive to a specified directory. e.g.: ```C:\libs\ffmpeg```.
+   - Add ffmpeg to your PATH
+   ```cmd
+    setx path "%PATH%;C:\libs\ffmpeg\bin"
+   ```
 
-2. Set the folder as an environment path variable.
 
-3. Make a folder in the location you want to download the songs in.
+## Launch
+   ```bash
+   $ ./ytd.py    # launch in interactive mode
+   ```
 
-4. Open PowerShell in that location.
+---
 
-   1. Click on the path of the folder.
-   2. Type in **`ytd.py -o --playlist PLAYLIST_LINK`** to download the entire playlist.
+### Launch Options
 
-5. **To download individual songs**
-
-   1. Open CMD at the Repository's location.
-      1. Type **`python ydl.py`**  - This will run the script.
-   2. Paste the link of the song. It will download it. 
-
-**To download the songs, follow these commands :-**
+Supported flags are explained below:
 
 | Command                                                                                                                                                                                              | Function                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -96,9 +91,3 @@ This project has been made for educational purposes using python language and do
 10. --default :- Downloads at the default download location. Usually the **downloads** folder.
 
 11. --default/Folder_Location :- Changes the default download path. Downloads at that path if a playlist is queued.
-
-#### Errors :-
-
-**For Windows :-**
-
-If you encounter Couldn't find FF Probe or AV Probe error, try to download [FFmpeg](https://ffmpeg.zeranoe.com/builds/). Traverse to the file location and open the **bin** folder and set that location as an environment path. That should solve the issue.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,3 @@
+# specifies dependencies common to production and development environments
+
+urllib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,4 @@
+# specifies development-specific requirements
+
+-r common.txt
+pytest

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+# specifies production-specific requirements
+
+-r common.txt


### PR DESCRIPTION
- Explicitly specify python dependencies through  ```requirements/{env}.txt```  files.
This follows the standard way of specifying module dependencies, making the script more easily portable.

- Provide a  ```Makefile```  to simplify installation process, and provides a standard way of defining launchable tasks (such as running of tests)

- Update and clean up the project README.