### PR TITLE
Remove redundant requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-youtube_dl
-urllib


### PR DESCRIPTION
requirements.txt specified:
- urllib, which is already specified as a runtime dependency of ytd.py
  in `requirements/common.txt`
- youtube_dl, which is already specified as runtime dependency in the
  `Makefile`, and will be installed by  `make install` , or
  `make install-dev`  goals.